### PR TITLE
don't publish .babelrc to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 .idea
 example
+.babelrc


### PR DESCRIPTION
Hi @vn38minhtran, thanks for this cool library!

Can we maybe remove the `.babelrc` file from the npm package?
The reasons for this are:
1) this is a file only needed at build-time. it's unnecessary at runtime.
2) when using browserify to bundle an application and then using babelify on all modules, then it thinks that it has to transpile this module again, because there is a `.babelrc` file, and will fail.

What do you think?