### PR TITLE
renamed deprecated unsafe lifecycle methods

### DIFF
--- a/example/src/components/Document.js
+++ b/example/src/components/Document.js
@@ -13,7 +13,7 @@ class Document extends React.Component {
     oldClassName: document.body.className,
   };
 
-  componentWillMount = () => {
+  UNSAFE_componentWillMount = () => {
     if (this.props.title) {
       document.title = this.props.title;
     }

--- a/src/NotificationContainer.js
+++ b/src/NotificationContainer.js
@@ -18,7 +18,7 @@ class NotificationContainer extends React.Component {
     notifications: []
   };
 
-  componentWillMount = () => {
+  UNSAFE_componentWillMount = () => {
     NotificationManager.addChangeListener(this.handleStoreChange);
   };
 


### PR DESCRIPTION
As of react 16.3, `componentWillMount`, `componentWillUpdate` and `componentWillReceiveProps` lifecycle methods needs to be renamed to supress the warning about deprecation.

![warning](https://user-images.githubusercontent.com/27023329/64509033-8c9eb380-d2e7-11e9-82ab-81d23c26c653.png)

more info here: https://hackernoon.com/problematic-react-lifecycle-methods-are-going-away-in-react-17-4216acc7d58b